### PR TITLE
Remove hardcoded 'amd64' from Dockerfile

### DIFF
--- a/images/descheduler/Dockerfile.rhel7
+++ b/images/descheduler/Dockerfile.rhel7
@@ -1,8 +1,10 @@
 FROM registry.svc.ci.openshift.org/ocp/builder:golang-1.10 AS builder
 WORKDIR /go/src/github.com/kubernetes-incubator/descheduler
 COPY . .
-RUN make build
+RUN make build; \
+    mkdir -p /tmp/build; \
+    cp /go/src/github.com/kubernetes-incubator/descheduler/_output/local/bin/linux/$(go env GOARCH)/descheduler /tmp/build/descheduler
 
 FROM registry.svc.ci.openshift.org/ocp/4.0:base
-COPY --from=builder /go/src/github.com/kubernetes-incubator/descheduler/_output/local/bin/linux/amd64/descheduler /usr/bin/
+COPY --from=builder /tmp/build/descheduler /usr/bin/
 CMD ["/usr/bin/descheduler"]


### PR DESCRIPTION
Remove hardcoded 'amd64' from Dockerfile to support multi-arch builds.