### PR TITLE
Fix build with golang-builder:1.13

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,7 +38,7 @@ JUNIT_REPORT ?= true
 #   make all
 #   make all WHAT=cmd/oc GOFLAGS=-v
 all build:
-	hack/build-go.sh $(WHAT) $(GOFLAGS)
+	GOFLAGS="$(GOFLAGS)" hack/build-go.sh $(WHAT)
 .PHONY: all build
 
 # Run core verification and all self contained tests.


### PR DESCRIPTION
GOFLAGS is exported as an environment variable in the 1.13 builder image
in order to work around behaviour changes wrt modules.  The Makefile
would only accept GOFLAGS correctly with WHAT was also defined,
otherwise it misinterprets the flag as the build target, resulting in
nothing being built.