### PR TITLE
Update references to kubernetes-incubator to now use sigs.k8s.io

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: go
 go:
-  - 1.8.3
+  - 1.13.x
 script:
 - hack/verify-gofmt.sh
 - make build

--- a/README.md
+++ b/README.md
@@ -26,6 +26,8 @@ but relies on the default scheduler for that.
 
 ## Build and Run
 
+- Checkout the repo into your $GOPATH directory under src/sigs.k8s.io/descheduler
+
 Build descheduler:
 
 ```sh

--- a/cmd/descheduler/app/options/options.go
+++ b/cmd/descheduler/app/options/options.go
@@ -21,10 +21,10 @@ import (
 	clientset "k8s.io/client-go/kubernetes"
 
 	// install the componentconfig api so we get its defaulting and conversion functions
-	"github.com/kubernetes-incubator/descheduler/pkg/apis/componentconfig"
-	_ "github.com/kubernetes-incubator/descheduler/pkg/apis/componentconfig/install"
-	"github.com/kubernetes-incubator/descheduler/pkg/apis/componentconfig/v1alpha1"
-	deschedulerscheme "github.com/kubernetes-incubator/descheduler/pkg/descheduler/scheme"
+	"sigs.k8s.io/descheduler/pkg/apis/componentconfig"
+	_ "sigs.k8s.io/descheduler/pkg/apis/componentconfig/install"
+	"sigs.k8s.io/descheduler/pkg/apis/componentconfig/v1alpha1"
+	deschedulerscheme "sigs.k8s.io/descheduler/pkg/descheduler/scheme"
 
 	"github.com/spf13/pflag"
 )

--- a/cmd/descheduler/app/server.go
+++ b/cmd/descheduler/app/server.go
@@ -21,8 +21,8 @@ import (
 	"flag"
 	"io"
 
-	"github.com/kubernetes-incubator/descheduler/cmd/descheduler/app/options"
-	"github.com/kubernetes-incubator/descheduler/pkg/descheduler"
+	"sigs.k8s.io/descheduler/cmd/descheduler/app/options"
+	"sigs.k8s.io/descheduler/pkg/descheduler"
 
 	"github.com/golang/glog"
 	"github.com/spf13/cobra"

--- a/cmd/descheduler/descheduler.go
+++ b/cmd/descheduler/descheduler.go
@@ -21,7 +21,7 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/kubernetes-incubator/descheduler/cmd/descheduler/app"
+	"sigs.k8s.io/descheduler/cmd/descheduler/app"
 )
 
 func main() {

--- a/hack/lib/constants.sh
+++ b/hack/lib/constants.sh
@@ -2,7 +2,7 @@
 
 # This script provides constants for the Golang binary build process
 
-readonly OS_GO_PACKAGE=github.com/kubernetes-incubator/descheduler
+readonly OS_GO_PACKAGE=sigs.k8s.io/descheduler
 
 readonly OS_BUILD_ENV_GOLANG="${OS_BUILD_ENV_GOLANG:-1.9}"
 readonly OS_BUILD_ENV_IMAGE="${OS_BUILD_ENV_IMAGE:-openshift/origin-release:golang-${OS_BUILD_ENV_GOLANG}}"

--- a/images/descheduler/Dockerfile.origin
+++ b/images/descheduler/Dockerfile.origin
@@ -1,8 +1,8 @@
 FROM registry.svc.ci.openshift.org/openshift/release:golang-1.10 AS builder
-WORKDIR /go/src/github.com/kubernetes-incubator/descheduler
+WORKDIR /go/src/sigs.k8s.io/descheduler
 COPY . .
 RUN make build
 
 FROM registry.svc.ci.openshift.org/openshift/origin-v4.0:base
-COPY --from=builder /go/src/github.com/kubernetes-incubator/descheduler/_output/local/bin/linux/amd64/descheduler /usr/bin/
+COPY --from=builder /go/src/sigs.k8s.io/descheduler/_output/local/bin/linux/amd64/descheduler /usr/bin/
 CMD ["/usr/bin/descheduler"]

--- a/images/descheduler/Dockerfile.rhel7
+++ b/images/descheduler/Dockerfile.rhel7
@@ -1,9 +1,9 @@
 FROM registry.svc.ci.openshift.org/ocp/builder:golang-1.10 AS builder
-WORKDIR /go/src/github.com/kubernetes-incubator/descheduler
+WORKDIR /go/src/sigs.k8s.io/descheduler
 COPY . .
 RUN make build; \
     mkdir -p /tmp/build; \
-    cp /go/src/github.com/kubernetes-incubator/descheduler/_output/local/bin/linux/$(go env GOARCH)/descheduler /tmp/build/descheduler
+    cp /go/src/sigs.k8s.io/descheduler/_output/local/bin/linux/$(go env GOARCH)/descheduler /tmp/build/descheduler
 
 FROM registry.svc.ci.openshift.org/ocp/4.0:base
 COPY --from=builder /tmp/build/descheduler /usr/bin/

--- a/pkg/api/doc.go
+++ b/pkg/api/doc.go
@@ -16,4 +16,4 @@ limitations under the License.
 
 // +k8s:deepcopy-gen=package,register
 
-package api // import "github.com/kubernetes-incubator/descheduler/pkg/api"
+package api // import "sigs.k8s.io/descheduler/pkg/api"

--- a/pkg/api/install/install.go
+++ b/pkg/api/install/install.go
@@ -22,9 +22,9 @@ import (
 	"k8s.io/apimachinery/pkg/apimachinery/registered"
 	"k8s.io/apimachinery/pkg/runtime"
 
-	deschedulerapi "github.com/kubernetes-incubator/descheduler/pkg/api"
-	"github.com/kubernetes-incubator/descheduler/pkg/api/v1alpha1"
-	deschedulerscheme "github.com/kubernetes-incubator/descheduler/pkg/descheduler/scheme"
+	deschedulerapi "sigs.k8s.io/descheduler/pkg/api"
+	"sigs.k8s.io/descheduler/pkg/api/v1alpha1"
+	deschedulerscheme "sigs.k8s.io/descheduler/pkg/descheduler/scheme"
 )
 
 func init() {

--- a/pkg/api/v1alpha1/doc.go
+++ b/pkg/api/v1alpha1/doc.go
@@ -15,10 +15,10 @@ limitations under the License.
 */
 
 // +k8s:deepcopy-gen=package,register
-// +k8s:conversion-gen=github.com/kubernetes-incubator/descheduler/pkg/api
+// +k8s:conversion-gen=sigs.k8s.io/descheduler/pkg/api
 // +k8s:defaulter-gen=TypeMeta
 
 // Package v1alpha1 is the v1alpha1 version of the descheduler API
 // +groupName=descheduler
 
-package v1alpha1 // import "github.com/kubernetes-incubator/descheduler/pkg/api/v1alpha1"
+package v1alpha1 // import "sigs.k8s.io/descheduler/pkg/api/v1alpha1"

--- a/pkg/api/v1alpha1/zz_generated.conversion.go
+++ b/pkg/api/v1alpha1/zz_generated.conversion.go
@@ -23,9 +23,9 @@ package v1alpha1
 import (
 	unsafe "unsafe"
 
-	api "github.com/kubernetes-incubator/descheduler/pkg/api"
 	conversion "k8s.io/apimachinery/pkg/conversion"
 	runtime "k8s.io/apimachinery/pkg/runtime"
+	api "sigs.k8s.io/descheduler/pkg/api"
 )
 
 func init() {

--- a/pkg/apis/componentconfig/doc.go
+++ b/pkg/apis/componentconfig/doc.go
@@ -16,4 +16,4 @@ limitations under the License.
 
 // +k8s:deepcopy-gen=package,register
 
-package componentconfig // import "github.com/kubernetes-incubator/descheduler/pkg/apis/componentconfig"
+package componentconfig // import "sigs.k8s.io/descheduler/pkg/apis/componentconfig"

--- a/pkg/apis/componentconfig/install/install.go
+++ b/pkg/apis/componentconfig/install/install.go
@@ -22,9 +22,9 @@ import (
 	"k8s.io/apimachinery/pkg/apimachinery/registered"
 	"k8s.io/apimachinery/pkg/runtime"
 
-	"github.com/kubernetes-incubator/descheduler/pkg/apis/componentconfig"
-	"github.com/kubernetes-incubator/descheduler/pkg/apis/componentconfig/v1alpha1"
-	deschedulerscheme "github.com/kubernetes-incubator/descheduler/pkg/descheduler/scheme"
+	"sigs.k8s.io/descheduler/pkg/apis/componentconfig"
+	"sigs.k8s.io/descheduler/pkg/apis/componentconfig/v1alpha1"
+	deschedulerscheme "sigs.k8s.io/descheduler/pkg/descheduler/scheme"
 )
 
 func init() {

--- a/pkg/apis/componentconfig/v1alpha1/doc.go
+++ b/pkg/apis/componentconfig/v1alpha1/doc.go
@@ -15,10 +15,10 @@ limitations under the License.
 */
 
 // +k8s:deepcopy-gen=package,register
-// +k8s:conversion-gen=github.com/kubernetes-incubator/descheduler/pkg/apis/componentconfig
+// +k8s:conversion-gen=sigs.k8s.io/descheduler/pkg/apis/componentconfig
 // +k8s:defaulter-gen=TypeMeta
 
 // Package v1alpha1 is the v1alpha1 version of the descheduler's componentconfig API
 // +groupName=deschedulercomponentconfig
 
-package v1alpha1 // import "github.com/kubernetes-incubator/descheduler/pkg/apis/componentconfig/v1alpha1"
+package v1alpha1 // import "sigs.k8s.io/descheduler/pkg/apis/componentconfig/v1alpha1"

--- a/pkg/apis/componentconfig/v1alpha1/zz_generated.conversion.go
+++ b/pkg/apis/componentconfig/v1alpha1/zz_generated.conversion.go
@@ -23,9 +23,9 @@ package v1alpha1
 import (
 	time "time"
 
-	componentconfig "github.com/kubernetes-incubator/descheduler/pkg/apis/componentconfig"
 	conversion "k8s.io/apimachinery/pkg/conversion"
 	runtime "k8s.io/apimachinery/pkg/runtime"
+	componentconfig "sigs.k8s.io/descheduler/pkg/apis/componentconfig"
 )
 
 func init() {

--- a/pkg/descheduler/descheduler.go
+++ b/pkg/descheduler/descheduler.go
@@ -21,11 +21,11 @@ import (
 
 	"github.com/golang/glog"
 
-	"github.com/kubernetes-incubator/descheduler/cmd/descheduler/app/options"
-	"github.com/kubernetes-incubator/descheduler/pkg/descheduler/client"
-	eutils "github.com/kubernetes-incubator/descheduler/pkg/descheduler/evictions/utils"
-	nodeutil "github.com/kubernetes-incubator/descheduler/pkg/descheduler/node"
-	"github.com/kubernetes-incubator/descheduler/pkg/descheduler/strategies"
+	"sigs.k8s.io/descheduler/cmd/descheduler/app/options"
+	"sigs.k8s.io/descheduler/pkg/descheduler/client"
+	eutils "sigs.k8s.io/descheduler/pkg/descheduler/evictions/utils"
+	nodeutil "sigs.k8s.io/descheduler/pkg/descheduler/node"
+	"sigs.k8s.io/descheduler/pkg/descheduler/strategies"
 )
 
 func Run(rs *options.DeschedulerServer) error {

--- a/pkg/descheduler/evictions/evictions.go
+++ b/pkg/descheduler/evictions/evictions.go
@@ -25,7 +25,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	clientset "k8s.io/client-go/kubernetes"
 
-	eutils "github.com/kubernetes-incubator/descheduler/pkg/descheduler/evictions/utils"
+	eutils "sigs.k8s.io/descheduler/pkg/descheduler/evictions/utils"
 )
 
 func EvictPod(client clientset.Interface, pod *v1.Pod, policyGroupVersion string, dryRun bool) (bool, error) {

--- a/pkg/descheduler/evictions/evictions_test.go
+++ b/pkg/descheduler/evictions/evictions_test.go
@@ -17,11 +17,11 @@ limitations under the License.
 package evictions
 
 import (
-	"github.com/kubernetes-incubator/descheduler/test"
 	"k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes/fake"
 	core "k8s.io/client-go/testing"
+	"sigs.k8s.io/descheduler/test"
 	"testing"
 )
 

--- a/pkg/descheduler/node/node.go
+++ b/pkg/descheduler/node/node.go
@@ -20,7 +20,6 @@ import (
 	"time"
 
 	"github.com/golang/glog"
-	"github.com/kubernetes-incubator/descheduler/pkg/utils"
 	"k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/fields"
@@ -28,6 +27,7 @@ import (
 	clientset "k8s.io/client-go/kubernetes"
 	corelisters "k8s.io/client-go/listers/core/v1"
 	"k8s.io/client-go/tools/cache"
+	"sigs.k8s.io/descheduler/pkg/utils"
 )
 
 // ReadyNodes returns ready nodes irrespective of whether they are

--- a/pkg/descheduler/node/node_test.go
+++ b/pkg/descheduler/node/node_test.go
@@ -19,10 +19,10 @@ package node
 import (
 	"testing"
 
-	"github.com/kubernetes-incubator/descheduler/test"
 	"k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes/fake"
+	"sigs.k8s.io/descheduler/test"
 )
 
 func TestReadyNodes(t *testing.T) {

--- a/pkg/descheduler/pod/pods_test.go
+++ b/pkg/descheduler/pod/pods_test.go
@@ -19,9 +19,9 @@ package pod
 import (
 	"testing"
 
-	"github.com/kubernetes-incubator/descheduler/test"
 	"k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
+	"sigs.k8s.io/descheduler/test"
 )
 
 func TestPodTypes(t *testing.T) {

--- a/pkg/descheduler/policyconfig.go
+++ b/pkg/descheduler/policyconfig.go
@@ -23,10 +23,10 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 
 	"github.com/golang/glog"
-	"github.com/kubernetes-incubator/descheduler/pkg/api"
-	_ "github.com/kubernetes-incubator/descheduler/pkg/api/install"
-	"github.com/kubernetes-incubator/descheduler/pkg/api/v1alpha1"
-	"github.com/kubernetes-incubator/descheduler/pkg/descheduler/scheme"
+	"sigs.k8s.io/descheduler/pkg/api"
+	_ "sigs.k8s.io/descheduler/pkg/api/install"
+	"sigs.k8s.io/descheduler/pkg/api/v1alpha1"
+	"sigs.k8s.io/descheduler/pkg/descheduler/scheme"
 )
 
 func LoadPolicyConfig(policyConfigFile string) (*api.DeschedulerPolicy, error) {

--- a/pkg/descheduler/strategies/duplicates.go
+++ b/pkg/descheduler/strategies/duplicates.go
@@ -24,10 +24,10 @@ import (
 	"k8s.io/api/core/v1"
 	clientset "k8s.io/client-go/kubernetes"
 
-	"github.com/kubernetes-incubator/descheduler/cmd/descheduler/app/options"
-	"github.com/kubernetes-incubator/descheduler/pkg/api"
-	"github.com/kubernetes-incubator/descheduler/pkg/descheduler/evictions"
-	podutil "github.com/kubernetes-incubator/descheduler/pkg/descheduler/pod"
+	"sigs.k8s.io/descheduler/cmd/descheduler/app/options"
+	"sigs.k8s.io/descheduler/pkg/api"
+	"sigs.k8s.io/descheduler/pkg/descheduler/evictions"
+	podutil "sigs.k8s.io/descheduler/pkg/descheduler/pod"
 )
 
 //type creator string

--- a/pkg/descheduler/strategies/duplicates_test.go
+++ b/pkg/descheduler/strategies/duplicates_test.go
@@ -19,12 +19,12 @@ package strategies
 import (
 	"testing"
 
-	"github.com/kubernetes-incubator/descheduler/test"
 	"k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes/fake"
 	core "k8s.io/client-go/testing"
+	"sigs.k8s.io/descheduler/test"
 )
 
 //TODO:@ravisantoshgudimetla This could be made table driven.

--- a/pkg/descheduler/strategies/lownodeutilization.go
+++ b/pkg/descheduler/strategies/lownodeutilization.go
@@ -25,11 +25,11 @@ import (
 	clientset "k8s.io/client-go/kubernetes"
 	helper "k8s.io/kubernetes/pkg/api/v1/resource"
 
-	"github.com/kubernetes-incubator/descheduler/cmd/descheduler/app/options"
-	"github.com/kubernetes-incubator/descheduler/pkg/api"
-	"github.com/kubernetes-incubator/descheduler/pkg/descheduler/evictions"
-	nodeutil "github.com/kubernetes-incubator/descheduler/pkg/descheduler/node"
-	podutil "github.com/kubernetes-incubator/descheduler/pkg/descheduler/pod"
+	"sigs.k8s.io/descheduler/cmd/descheduler/app/options"
+	"sigs.k8s.io/descheduler/pkg/api"
+	"sigs.k8s.io/descheduler/pkg/descheduler/evictions"
+	nodeutil "sigs.k8s.io/descheduler/pkg/descheduler/node"
+	podutil "sigs.k8s.io/descheduler/pkg/descheduler/pod"
 )
 
 type NodeUsageMap struct {

--- a/pkg/descheduler/strategies/lownodeutilization_test.go
+++ b/pkg/descheduler/strategies/lownodeutilization_test.go
@@ -21,13 +21,13 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/kubernetes-incubator/descheduler/pkg/api"
-	"github.com/kubernetes-incubator/descheduler/test"
 	"k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes/fake"
 	core "k8s.io/client-go/testing"
+	"sigs.k8s.io/descheduler/pkg/api"
+	"sigs.k8s.io/descheduler/test"
 )
 
 // TODO: Make this table driven.

--- a/pkg/descheduler/strategies/node_affinity.go
+++ b/pkg/descheduler/strategies/node_affinity.go
@@ -18,12 +18,12 @@ package strategies
 
 import (
 	"github.com/golang/glog"
-	"github.com/kubernetes-incubator/descheduler/cmd/descheduler/app/options"
-	"github.com/kubernetes-incubator/descheduler/pkg/api"
-	"github.com/kubernetes-incubator/descheduler/pkg/descheduler/evictions"
-	nodeutil "github.com/kubernetes-incubator/descheduler/pkg/descheduler/node"
-	podutil "github.com/kubernetes-incubator/descheduler/pkg/descheduler/pod"
 	"k8s.io/api/core/v1"
+	"sigs.k8s.io/descheduler/cmd/descheduler/app/options"
+	"sigs.k8s.io/descheduler/pkg/api"
+	"sigs.k8s.io/descheduler/pkg/descheduler/evictions"
+	nodeutil "sigs.k8s.io/descheduler/pkg/descheduler/node"
+	podutil "sigs.k8s.io/descheduler/pkg/descheduler/pod"
 )
 
 func RemovePodsViolatingNodeAffinity(ds *options.DeschedulerServer, strategy api.DeschedulerStrategy, evictionPolicyGroupVersion string, nodes []*v1.Node, nodePodCount nodePodEvictedCount) {

--- a/pkg/descheduler/strategies/node_affinity_test.go
+++ b/pkg/descheduler/strategies/node_affinity_test.go
@@ -19,13 +19,13 @@ package strategies
 import (
 	"testing"
 
-	"github.com/kubernetes-incubator/descheduler/cmd/descheduler/app/options"
-	"github.com/kubernetes-incubator/descheduler/pkg/api"
-	"github.com/kubernetes-incubator/descheduler/test"
 	"k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes/fake"
 	core "k8s.io/client-go/testing"
+	"sigs.k8s.io/descheduler/cmd/descheduler/app/options"
+	"sigs.k8s.io/descheduler/pkg/api"
+	"sigs.k8s.io/descheduler/test"
 )
 
 func TestRemovePodsViolatingNodeAffinity(t *testing.T) {
@@ -106,10 +106,10 @@ func TestRemovePodsViolatingNodeAffinity(t *testing.T) {
 				},
 			},
 			expectedEvictedPodCount: 0,
-			pods:           addPodsToNode(nodeWithoutLabels),
-			nodes:          []*v1.Node{nodeWithoutLabels, nodeWithLabels},
-			npe:            nodePodEvictedCount{nodeWithoutLabels: 0, nodeWithLabels: 0},
-			maxPodsToEvict: 0,
+			pods:                    addPodsToNode(nodeWithoutLabels),
+			nodes:                   []*v1.Node{nodeWithoutLabels, nodeWithLabels},
+			npe:                     nodePodEvictedCount{nodeWithoutLabels: 0, nodeWithLabels: 0},
+			maxPodsToEvict:          0,
 		},
 		{
 			description: "Invalid strategy type, should not evict any pods",
@@ -122,19 +122,19 @@ func TestRemovePodsViolatingNodeAffinity(t *testing.T) {
 				},
 			},
 			expectedEvictedPodCount: 0,
-			pods:           addPodsToNode(nodeWithoutLabels),
-			nodes:          []*v1.Node{nodeWithoutLabels, nodeWithLabels},
-			npe:            nodePodEvictedCount{nodeWithoutLabels: 0, nodeWithLabels: 0},
-			maxPodsToEvict: 0,
+			pods:                    addPodsToNode(nodeWithoutLabels),
+			nodes:                   []*v1.Node{nodeWithoutLabels, nodeWithLabels},
+			npe:                     nodePodEvictedCount{nodeWithoutLabels: 0, nodeWithLabels: 0},
+			maxPodsToEvict:          0,
 		},
 		{
 			description:             "Pod is correctly scheduled on node, no eviction expected",
 			strategy:                requiredDuringSchedulingIgnoredDuringExecutionStrategy,
 			expectedEvictedPodCount: 0,
-			pods:           addPodsToNode(nodeWithLabels),
-			nodes:          []*v1.Node{nodeWithLabels},
-			npe:            nodePodEvictedCount{nodeWithLabels: 0},
-			maxPodsToEvict: 0,
+			pods:                    addPodsToNode(nodeWithLabels),
+			nodes:                   []*v1.Node{nodeWithLabels},
+			npe:                     nodePodEvictedCount{nodeWithLabels: 0},
+			maxPodsToEvict:          0,
 		},
 		{
 			description:             "Pod is scheduled on node without matching labels, another schedulable node available, should be evicted",

--- a/pkg/descheduler/strategies/pod_antiaffinity.go
+++ b/pkg/descheduler/strategies/pod_antiaffinity.go
@@ -17,10 +17,10 @@ limitations under the License.
 package strategies
 
 import (
-	"github.com/kubernetes-incubator/descheduler/cmd/descheduler/app/options"
-	"github.com/kubernetes-incubator/descheduler/pkg/api"
-	"github.com/kubernetes-incubator/descheduler/pkg/descheduler/evictions"
-	podutil "github.com/kubernetes-incubator/descheduler/pkg/descheduler/pod"
+	"sigs.k8s.io/descheduler/cmd/descheduler/app/options"
+	"sigs.k8s.io/descheduler/pkg/api"
+	"sigs.k8s.io/descheduler/pkg/descheduler/evictions"
+	podutil "sigs.k8s.io/descheduler/pkg/descheduler/pod"
 
 	"github.com/golang/glog"
 

--- a/pkg/descheduler/strategies/pod_antiaffinity_test.go
+++ b/pkg/descheduler/strategies/pod_antiaffinity_test.go
@@ -19,12 +19,12 @@ package strategies
 import (
 	"testing"
 
-	"github.com/kubernetes-incubator/descheduler/test"
 	"k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes/fake"
 	core "k8s.io/client-go/testing"
+	"sigs.k8s.io/descheduler/test"
 )
 
 func TestPodAntiAffinity(t *testing.T) {

--- a/tools/import-verifier/import-verifier.go
+++ b/tools/import-verifier/import-verifier.go
@@ -13,7 +13,7 @@ import (
 )
 
 const (
-	rootPackage = "github.com/kubernetes-incubator/descheduler"
+	rootPackage = "sigs.k8s.io/descheduler"
 )
 
 // Package is a subset of cmd/go.Package
@@ -62,7 +62,7 @@ func (i *ImportRestriction) ForbiddenImportsFor(pkg Package) []string {
 //   - it does not fall under any of the ignored sub-trees
 func (i *ImportRestriction) isRestrictedPath(packageToCheck string) bool {
 	// if its not under our root, then its a built-in.  Everything else is under
-	// github.com/kubernetes-incubator/descheduler or github.com/kubernetes-incubator/descheduler/vendor
+	// sigs.k8s.io/descheduler or sigs.k8s.io/descheduler/vendor
 	if !strings.HasPrefix(packageToCheck, rootPackage) {
 		return false
 	}
@@ -103,7 +103,7 @@ func (i *ImportRestriction) forbiddenImportsFor(pkg Package) []string {
 //   - is not of an allowed path or a sub-package of one
 func (i *ImportRestriction) isAllowed(packageToCheck string) bool {
 	// if its not under our root, then its a built-in.  Everything else is under
-	// github.com/kubernetes-incubator/descheduler or github.com/kubernetes-incubator/descheduler/vendor
+	// sigs.k8s.io/descheduler or sigs.k8s.io/descheduler/vendor
 	if !strings.HasPrefix(packageToCheck, rootPackage) {
 		return true
 	}

--- a/tools/junitreport/junitreport.go
+++ b/tools/junitreport/junitreport.go
@@ -7,7 +7,7 @@ import (
 	"os"
 	"strings"
 
-	"github.com/kubernetes-incubator/descheduler/tools/junitreport/pkg/cmd"
+	"sigs.k8s.io/descheduler/tools/junitreport/pkg/cmd"
 )
 
 var (

--- a/tools/junitreport/pkg/builder/flat/test_suites_builder.go
+++ b/tools/junitreport/pkg/builder/flat/test_suites_builder.go
@@ -1,8 +1,8 @@
 package flat
 
 import (
-	"github.com/kubernetes-incubator/descheduler/tools/junitreport/pkg/api"
-	"github.com/kubernetes-incubator/descheduler/tools/junitreport/pkg/builder"
+	"sigs.k8s.io/descheduler/tools/junitreport/pkg/api"
+	"sigs.k8s.io/descheduler/tools/junitreport/pkg/builder"
 )
 
 // NewTestSuitesBuilder returns a new flat test suites builder. All test suites consumed

--- a/tools/junitreport/pkg/builder/flat/test_suites_builder_test.go
+++ b/tools/junitreport/pkg/builder/flat/test_suites_builder_test.go
@@ -4,7 +4,7 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/kubernetes-incubator/descheduler/tools/junitreport/pkg/api"
+	"sigs.k8s.io/descheduler/tools/junitreport/pkg/api"
 )
 
 func TestAddSuite(t *testing.T) {

--- a/tools/junitreport/pkg/builder/interfaces.go
+++ b/tools/junitreport/pkg/builder/interfaces.go
@@ -1,6 +1,6 @@
 package builder
 
-import "github.com/kubernetes-incubator/descheduler/tools/junitreport/pkg/api"
+import "sigs.k8s.io/descheduler/tools/junitreport/pkg/api"
 
 // TestSuitesBuilder knows how to aggregate data to form a collection of test suites.
 type TestSuitesBuilder interface {

--- a/tools/junitreport/pkg/builder/nested/test_suites_builder.go
+++ b/tools/junitreport/pkg/builder/nested/test_suites_builder.go
@@ -4,8 +4,8 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/kubernetes-incubator/descheduler/tools/junitreport/pkg/api"
-	"github.com/kubernetes-incubator/descheduler/tools/junitreport/pkg/builder"
+	"sigs.k8s.io/descheduler/tools/junitreport/pkg/api"
+	"sigs.k8s.io/descheduler/tools/junitreport/pkg/builder"
 )
 
 // NewTestSuitesBuilder returns a new nested test suites builder. All test suites consumed by

--- a/tools/junitreport/pkg/builder/nested/test_suites_builder_test.go
+++ b/tools/junitreport/pkg/builder/nested/test_suites_builder_test.go
@@ -4,7 +4,7 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/kubernetes-incubator/descheduler/tools/junitreport/pkg/api"
+	"sigs.k8s.io/descheduler/tools/junitreport/pkg/api"
 )
 
 func TestGetParentName(t *testing.T) {

--- a/tools/junitreport/pkg/cmd/junitreport.go
+++ b/tools/junitreport/pkg/cmd/junitreport.go
@@ -6,12 +6,12 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/kubernetes-incubator/descheduler/tools/junitreport/pkg/builder"
-	"github.com/kubernetes-incubator/descheduler/tools/junitreport/pkg/builder/flat"
-	"github.com/kubernetes-incubator/descheduler/tools/junitreport/pkg/builder/nested"
-	"github.com/kubernetes-incubator/descheduler/tools/junitreport/pkg/parser"
-	"github.com/kubernetes-incubator/descheduler/tools/junitreport/pkg/parser/gotest"
-	"github.com/kubernetes-incubator/descheduler/tools/junitreport/pkg/parser/oscmd"
+	"sigs.k8s.io/descheduler/tools/junitreport/pkg/builder"
+	"sigs.k8s.io/descheduler/tools/junitreport/pkg/builder/flat"
+	"sigs.k8s.io/descheduler/tools/junitreport/pkg/builder/nested"
+	"sigs.k8s.io/descheduler/tools/junitreport/pkg/parser"
+	"sigs.k8s.io/descheduler/tools/junitreport/pkg/parser/gotest"
+	"sigs.k8s.io/descheduler/tools/junitreport/pkg/parser/oscmd"
 )
 
 type testSuitesBuilderType string

--- a/tools/junitreport/pkg/cmd/summarize.go
+++ b/tools/junitreport/pkg/cmd/summarize.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/kubernetes-incubator/descheduler/tools/junitreport/pkg/api"
+	"sigs.k8s.io/descheduler/tools/junitreport/pkg/api"
 )
 
 // Summarize reads the input into a TestSuites structure and summarizes the tests contained within,

--- a/tools/junitreport/pkg/parser/gotest/data_parser.go
+++ b/tools/junitreport/pkg/parser/gotest/data_parser.go
@@ -3,7 +3,7 @@ package gotest
 import (
 	"regexp"
 
-	"github.com/kubernetes-incubator/descheduler/tools/junitreport/pkg/api"
+	"sigs.k8s.io/descheduler/tools/junitreport/pkg/api"
 )
 
 // testStartPattern matches the line in verbose `go test` output that marks the declaration of a test.

--- a/tools/junitreport/pkg/parser/gotest/data_parser_test.go
+++ b/tools/junitreport/pkg/parser/gotest/data_parser_test.go
@@ -4,7 +4,7 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/kubernetes-incubator/descheduler/tools/junitreport/pkg/api"
+	"sigs.k8s.io/descheduler/tools/junitreport/pkg/api"
 )
 
 func TestExtractRunOk(t *testing.T) {

--- a/tools/junitreport/pkg/parser/gotest/parser.go
+++ b/tools/junitreport/pkg/parser/gotest/parser.go
@@ -5,9 +5,9 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/kubernetes-incubator/descheduler/tools/junitreport/pkg/api"
-	"github.com/kubernetes-incubator/descheduler/tools/junitreport/pkg/builder"
-	"github.com/kubernetes-incubator/descheduler/tools/junitreport/pkg/parser"
+	"sigs.k8s.io/descheduler/tools/junitreport/pkg/api"
+	"sigs.k8s.io/descheduler/tools/junitreport/pkg/builder"
+	"sigs.k8s.io/descheduler/tools/junitreport/pkg/parser"
 )
 
 // NewParser returns a new parser that's capable of parsing Go unit test output

--- a/tools/junitreport/pkg/parser/gotest/parser_flat_test.go
+++ b/tools/junitreport/pkg/parser/gotest/parser_flat_test.go
@@ -6,8 +6,8 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/kubernetes-incubator/descheduler/tools/junitreport/pkg/api"
-	"github.com/kubernetes-incubator/descheduler/tools/junitreport/pkg/builder/flat"
+	"sigs.k8s.io/descheduler/tools/junitreport/pkg/api"
+	"sigs.k8s.io/descheduler/tools/junitreport/pkg/builder/flat"
 )
 
 // TestFlatParse tests that parsing the `go test` output in the test directory with a flat builder works as expected

--- a/tools/junitreport/pkg/parser/gotest/parser_nested_test.go
+++ b/tools/junitreport/pkg/parser/gotest/parser_nested_test.go
@@ -8,8 +8,8 @@ import (
 
 	"k8s.io/apimachinery/pkg/util/diff"
 
-	"github.com/kubernetes-incubator/descheduler/tools/junitreport/pkg/api"
-	"github.com/kubernetes-incubator/descheduler/tools/junitreport/pkg/builder/nested"
+	"sigs.k8s.io/descheduler/tools/junitreport/pkg/api"
+	"sigs.k8s.io/descheduler/tools/junitreport/pkg/builder/nested"
 )
 
 // TestNestedParse tests that parsing the `go test` output in the test directory with a nested builder works as expected
@@ -450,7 +450,7 @@ func TestNestedParse(t *testing.T) {
 						},
 					},
 					{
-						Name:       "github.com/kubernetes-incubator/descheduler/tools/junitreport/pkg/parser/gotest/example",
+						Name:       "sigs.k8s.io/descheduler/tools/junitreport/pkg/parser/gotest/example",
 						NumTests:   19,
 						NumFailed:  9,
 						Duration:   0.006,

--- a/tools/junitreport/pkg/parser/interfaces.go
+++ b/tools/junitreport/pkg/parser/interfaces.go
@@ -3,7 +3,7 @@ package parser
 import (
 	"bufio"
 
-	"github.com/kubernetes-incubator/descheduler/tools/junitreport/pkg/api"
+	"sigs.k8s.io/descheduler/tools/junitreport/pkg/api"
 )
 
 // TestOutputParser knows how to parse test output to create a collection of test suites

--- a/tools/junitreport/pkg/parser/oscmd/data_parser.go
+++ b/tools/junitreport/pkg/parser/oscmd/data_parser.go
@@ -3,8 +3,8 @@ package oscmd
 import (
 	"regexp"
 
-	"github.com/kubernetes-incubator/descheduler/tools/junitreport/pkg/api"
-	"github.com/kubernetes-incubator/descheduler/tools/junitreport/pkg/parser/stack"
+	"sigs.k8s.io/descheduler/tools/junitreport/pkg/api"
+	"sigs.k8s.io/descheduler/tools/junitreport/pkg/parser/stack"
 )
 
 func newTestDataParser() stack.TestDataParser {

--- a/tools/junitreport/pkg/parser/oscmd/data_parser_test.go
+++ b/tools/junitreport/pkg/parser/oscmd/data_parser_test.go
@@ -3,7 +3,7 @@ package oscmd
 import (
 	"testing"
 
-	"github.com/kubernetes-incubator/descheduler/tools/junitreport/pkg/api"
+	"sigs.k8s.io/descheduler/tools/junitreport/pkg/api"
 )
 
 func TestMarksTestBeginning(t *testing.T) {

--- a/tools/junitreport/pkg/parser/oscmd/parser.go
+++ b/tools/junitreport/pkg/parser/oscmd/parser.go
@@ -1,9 +1,9 @@
 package oscmd
 
 import (
-	"github.com/kubernetes-incubator/descheduler/tools/junitreport/pkg/builder"
-	"github.com/kubernetes-incubator/descheduler/tools/junitreport/pkg/parser"
-	"github.com/kubernetes-incubator/descheduler/tools/junitreport/pkg/parser/stack"
+	"sigs.k8s.io/descheduler/tools/junitreport/pkg/builder"
+	"sigs.k8s.io/descheduler/tools/junitreport/pkg/parser"
+	"sigs.k8s.io/descheduler/tools/junitreport/pkg/parser/stack"
 )
 
 // NewParser returns a new parser that's capable of parsing `os::cmd` test output

--- a/tools/junitreport/pkg/parser/oscmd/parser_flat_test.go
+++ b/tools/junitreport/pkg/parser/oscmd/parser_flat_test.go
@@ -6,8 +6,8 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/kubernetes-incubator/descheduler/tools/junitreport/pkg/api"
-	"github.com/kubernetes-incubator/descheduler/tools/junitreport/pkg/builder/flat"
+	"sigs.k8s.io/descheduler/tools/junitreport/pkg/api"
+	"sigs.k8s.io/descheduler/tools/junitreport/pkg/builder/flat"
 )
 
 // TestFlatParse tests that parsing the `os::cmd` output in the test directory with a flat builder works as expected

--- a/tools/junitreport/pkg/parser/oscmd/parser_nested_test.go
+++ b/tools/junitreport/pkg/parser/oscmd/parser_nested_test.go
@@ -6,8 +6,8 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/kubernetes-incubator/descheduler/tools/junitreport/pkg/api"
-	"github.com/kubernetes-incubator/descheduler/tools/junitreport/pkg/builder/nested"
+	"sigs.k8s.io/descheduler/tools/junitreport/pkg/api"
+	"sigs.k8s.io/descheduler/tools/junitreport/pkg/builder/nested"
 )
 
 // TestNestedParse tests that parsing the `go test` output in the test directory with a nested builder works as expected

--- a/tools/junitreport/pkg/parser/stack/interfaces.go
+++ b/tools/junitreport/pkg/parser/stack/interfaces.go
@@ -1,6 +1,6 @@
 package stack
 
-import "github.com/kubernetes-incubator/descheduler/tools/junitreport/pkg/api"
+import "sigs.k8s.io/descheduler/tools/junitreport/pkg/api"
 
 // TestDataParser knows how to take raw test data and extract the useful information from it
 type TestDataParser interface {

--- a/tools/junitreport/pkg/parser/stack/parser.go
+++ b/tools/junitreport/pkg/parser/stack/parser.go
@@ -6,9 +6,9 @@ import (
 	"os"
 	"strings"
 
-	"github.com/kubernetes-incubator/descheduler/tools/junitreport/pkg/api"
-	"github.com/kubernetes-incubator/descheduler/tools/junitreport/pkg/builder"
-	"github.com/kubernetes-incubator/descheduler/tools/junitreport/pkg/parser"
+	"sigs.k8s.io/descheduler/tools/junitreport/pkg/api"
+	"sigs.k8s.io/descheduler/tools/junitreport/pkg/builder"
+	"sigs.k8s.io/descheduler/tools/junitreport/pkg/parser"
 )
 
 // NewParser returns a new parser that's capable of parsing Go unit test output

--- a/tools/junitreport/pkg/parser/stack/stack.go
+++ b/tools/junitreport/pkg/parser/stack/stack.go
@@ -3,7 +3,7 @@ package stack
 import (
 	"fmt"
 
-	"github.com/kubernetes-incubator/descheduler/tools/junitreport/pkg/api"
+	"sigs.k8s.io/descheduler/tools/junitreport/pkg/api"
 )
 
 // TestSuiteStack is a data structure that holds api.TestSuite objects in a LIFO

--- a/tools/junitreport/pkg/parser/stack/stack_test.go
+++ b/tools/junitreport/pkg/parser/stack/stack_test.go
@@ -4,7 +4,7 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/kubernetes-incubator/descheduler/tools/junitreport/pkg/api"
+	"sigs.k8s.io/descheduler/tools/junitreport/pkg/api"
 )
 
 func TestPush(t *testing.T) {


### PR DESCRIPTION
For the rebase, this is required. And may be mutually blocking with https://github.com/openshift/release/pull/6824