### PR TITLE
Simplify dockerfile build step

### DIFF
--- a/images/descheduler/Dockerfile.origin
+++ b/images/descheduler/Dockerfile.origin
@@ -1,8 +1,8 @@
 FROM registry.svc.ci.openshift.org/openshift/release:golang-1.13 AS builder
 WORKDIR /go/src/sigs.k8s.io/descheduler
 COPY . .
-RUN make build WHAT=cmd/descheduler
+RUN go build -o descheduler ./cmd/descheduler
 
 FROM registry.svc.ci.openshift.org/openshift/origin-v4.0:base
-COPY --from=builder /go/src/sigs.k8s.io/descheduler/_output/local/bin/linux/amd64/descheduler /usr/bin/
+COPY --from=builder /go/src/sigs.k8s.io/descheduler/descheduler /usr/bin/
 CMD ["/usr/bin/descheduler"]

--- a/images/descheduler/Dockerfile.rhel7
+++ b/images/descheduler/Dockerfile.rhel7
@@ -1,10 +1,8 @@
 FROM registry.svc.ci.openshift.org/ocp/builder:golang-1.13 AS builder
 WORKDIR /go/src/sigs.k8s.io/descheduler
 COPY . .
-RUN make build WHAT=cmd/descheduler; \
-    mkdir -p /tmp/build; \
-    cp /go/src/sigs.k8s.io/descheduler/_output/local/bin/linux/$(go env GOARCH)/descheduler /tmp/build/descheduler
+RUN go build -o descheduler ./cmd/descheduler
 
 FROM registry.svc.ci.openshift.org/ocp/4.0:base
-COPY --from=builder /tmp/build/descheduler /usr/bin/
+COPY --from=builder /go/src/sigs.k8s.io/descheduler/descheduler /usr/bin/
 CMD ["/usr/bin/descheduler"]


### PR DESCRIPTION
Let's refrain from using scripts where it's not easily obvious what is being done.
Running simple go build will be easier to debug than investigating shell scripts that
at the end call go build/install.