### PR TITLE
Bug 1867148: Pull upstream changes (RemoveDuplicates panic bugfix)

### DIFF
--- a/charts/descheduler/README.md
+++ b/charts/descheduler/README.md
@@ -45,8 +45,8 @@ The following table lists the configurable parameters of the _descheduler_ chart
 
 | Parameter                      | Description                                                                                                           | Default                                                |
 | ------------------------------ | --------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------ |
-| `image.repository`             | Docker repository to use                                                                                              | `us.gcr.io/k8s-artifacts-prod/descheduler/descheduler` |
-| `image.tag`                    | Docker tag to use                                                                                                     | `v[chart appVersion]`                                              |
+| `image.repository`             | Docker repository to use                                                                                              | `k8s.gcr.io/descheduler/descheduler`                   |
+| `image.tag`                    | Docker tag to use                                                                                                     | `v[chart appVersion]`                                  |
 | `image.pullPolicy`             | Docker image pull policy                                                                                              | `IfNotPresent`                                         |
 | `nameOverride`                 | String to partially override `descheduler.fullname` template (will prepend the release name)                          | `""`                                                   |
 | `fullnameOverride`             | String to fully override `descheduler.fullname` template                                                              | `""`                                                   |

--- a/charts/descheduler/values.yaml
+++ b/charts/descheduler/values.yaml
@@ -3,7 +3,7 @@
 # Declare variables to be passed into your templates.
 
 image:
-  repository: us.gcr.io/k8s-artifacts-prod/descheduler/descheduler
+  repository: k8s.gcr.io/descheduler/descheduler
   # Overrides the image tag whose default is the chart version
   tag: ""
   pullPolicy: IfNotPresent

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -1,9 +1,7 @@
 # User Guide
 
-Starting with descheduler release v0.10.0 container images are available in these container registries.
-* `asia.gcr.io/k8s-artifacts-prod/descheduler/descheduler`
-* `eu.gcr.io/k8s-artifacts-prod/descheduler/descheduler`
-* `us.gcr.io/k8s-artifacts-prod/descheduler/descheduler`
+Starting with descheduler release v0.10.0 container images are available in the official k8s container registry.
+* `k8s.gcr.io/descheduler/descheduler`
 
 ## Policy Configuration Examples
 The [examples](https://github.com/kubernetes-sigs/descheduler/tree/master/examples) directory has descheduler policy configuration examples.

--- a/kubernetes/cronjob.yaml
+++ b/kubernetes/cronjob.yaml
@@ -16,7 +16,7 @@ spec:
           priorityClassName: system-cluster-critical
           containers:
           - name: descheduler
-            image: us.gcr.io/k8s-artifacts-prod/descheduler/descheduler:v0.18.0
+            image: k8s.gcr.io/descheduler/descheduler:v0.18.0
             volumeMounts:
             - mountPath: /policy-dir
               name: policy-volume

--- a/kubernetes/job.yaml
+++ b/kubernetes/job.yaml
@@ -14,7 +14,7 @@ spec:
       priorityClassName: system-cluster-critical
       containers:
         - name: descheduler
-          image: us.gcr.io/k8s-artifacts-prod/descheduler/descheduler:v0.18.0
+          image: k8s.gcr.io/descheduler/descheduler:v0.18.0
           volumeMounts:
           - mountPath: /policy-dir
             name: policy-volume

--- a/pkg/descheduler/strategies/duplicates.go
+++ b/pkg/descheduler/strategies/duplicates.go
@@ -69,7 +69,7 @@ func RemoveDuplicatePods(
 		duplicateKeysMap := map[string][][]string{}
 		for _, pod := range pods {
 			ownerRefList := podutil.OwnerRef(pod)
-			if hasExcludedOwnerRefKind(ownerRefList, strategy) {
+			if hasExcludedOwnerRefKind(ownerRefList, strategy) || len(ownerRefList) == 0 {
 				continue
 			}
 			podContainerKeys := make([]string, 0, len(ownerRefList)*len(pod.Spec.Containers))

--- a/pkg/descheduler/strategies/pod_antiaffinity.go
+++ b/pkg/descheduler/strategies/pod_antiaffinity.go
@@ -46,6 +46,10 @@ func validateRemovePodsViolatingInterPodAntiAffinityParams(params *api.StrategyP
 
 // RemovePodsViolatingInterPodAntiAffinity evicts pods on the node which are having a pod affinity rules.
 func RemovePodsViolatingInterPodAntiAffinity(ctx context.Context, client clientset.Interface, strategy api.DeschedulerStrategy, nodes []*v1.Node, podEvictor *evictions.PodEvictor) {
+	if err := validateRemovePodsViolatingInterPodAntiAffinityParams(strategy.Params); err != nil {
+		klog.V(1).Info(err)
+		return
+	}
 	var namespaces api.Namespaces
 	if strategy.Params != nil {
 		namespaces = strategy.Params.Namespaces


### PR DESCRIPTION
This pulls in the upstream/master changes, but notably the fix included in https://github.com/kubernetes-sigs/descheduler/pull/369 to address RemoveDuplicates panicing on a pod with no ownerrefs.
/kind bug