### PR TITLE
Updating atomic-openshift-descheduler builder & base images to be consistent with ART

### DIFF
--- a/images/descheduler/Dockerfile.rhel7
+++ b/images/descheduler/Dockerfile.rhel7
@@ -1,8 +1,8 @@
-FROM registry.svc.ci.openshift.org/ocp/builder:rhel-8-golang-1.15-openshift-4.6 AS builder
+FROM registry.svc.ci.openshift.org/ocp/builder:rhel-8-golang-1.15-openshift-4.7 AS builder
 WORKDIR /go/src/sigs.k8s.io/descheduler
 COPY . .
 RUN go build -o descheduler ./cmd/descheduler
 
-FROM registry.svc.ci.openshift.org/ocp/builder:rhel-8-base-openshift-4.6
+FROM registry.svc.ci.openshift.org/ocp/builder:rhel-8-base-openshift
 COPY --from=builder /go/src/sigs.k8s.io/descheduler/descheduler /usr/bin/
 CMD ["/usr/bin/descheduler"]


### PR DESCRIPTION
Updating atomic-openshift-descheduler builder & base images to be consistent with ART
Reconciling with https://github.com/openshift/ocp-build-data/tree/f66c03011773dc3755ad874fc691be612914d65f/images/atomic-openshift-descheduler.yml

If you have any questions about this pull request, please reach out to `@art-team` in the `#aos-art` coreos slack channel.
