### PR TITLE
Bug 1904501: sync upstream

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,8 +15,9 @@ FROM golang:1.15.5
 
 WORKDIR /go/src/sigs.k8s.io/descheduler
 COPY . .
+ARG ARCH
 ARG VERSION
-RUN VERSION=${VERSION} make
+RUN VERSION=${VERSION} make build.$ARCH
 
 FROM scratch
 

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -1,0 +1,24 @@
+# See https://cloud.google.com/cloud-build/docs/build-config
+
+# this must be specified in seconds. If omitted, defaults to 600s (10 mins)
+timeout: 1200s
+# this prevents errors if you don't use both _GIT_TAG and _PULL_BASE_REF,
+# or any new substitutions added in the future.
+options:
+  substitution_option: ALLOW_LOOSE
+steps:
+  - name: 'gcr.io/k8s-testimages/gcb-docker-gcloud:v20190906-745fed4'
+    entrypoint: make
+    env:
+    - DOCKER_CLI_EXPERIMENTAL=enabled
+    - VERSION=$_GIT_TAG
+    - BASE_REF=$_PULL_BASE_REF
+    args:
+    - push-all
+substitutions:
+  # _GIT_TAG will be filled with a git-based tag for the image, of the form vYYYYMMDD-hash, and
+  # can be used as a substitution
+  _GIT_TAG: '12345'
+  # _PULL_BASE_REF will contain the ref that was pushed to to trigger this build -
+  # a branch like 'master' or 'release-0.2', or a tag like 'v0.2'.
+  _PULL_BASE_REF: 'master'

--- a/docs/release-guide.md
+++ b/docs/release-guide.md
@@ -20,7 +20,7 @@
 3. Push the release branch to the descheuler repo and ensure branch protection is enabled (not required for patch releases)
 4. Tag the repository from the `master` branch (from the `release-1.18` branch for a patch release) and push the tag `VERSION=v0.18.0 git tag -m $VERSION $VERSION; git push origin $VERSION`
 5. Checkout the tag you just created and make sure your repo is clean by git's standards `git checkout $VERSION`
-6. Build and push the container image to the staging registry `VERSION=$VERSION make push`
+6. Build and push the container image to the staging registry `VERSION=$VERSION make push-all`
 7. Publish a draft release using the tag you just created
 8. Perform the [image promotion process](https://github.com/kubernetes/k8s.io/tree/master/k8s.gcr.io#image-promoter)
 9. Publish release

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -3,6 +3,16 @@
 Starting with descheduler release v0.10.0 container images are available in the official k8s container registry.
 * `k8s.gcr.io/descheduler/descheduler`
 
+Also, starting with descheduler release v0.20.0 multi-arch container images are provided. Currently AMD64 and ARM64
+container images are provided. Multi-arch container images cannot be pulled by [kind](https://kind.sigs.k8s.io) from
+a registry. Therefore starting with descheduler release v0.20.0 use the below process to download the official descheduler
+image into a kind cluster.
+```
+kind create cluster
+docker pull k8s.gcr.io/descheduler/descheduler:v0.20.0
+kind load docker-image k8s.gcr.io/descheduler/descheduler:v0.20.0
+```
+
 ## Policy Configuration Examples
 The [examples](https://github.com/kubernetes-sigs/descheduler/tree/master/examples) directory has descheduler policy configuration examples.
 

--- a/pkg/descheduler/strategies/topologyspreadconstraint.go
+++ b/pkg/descheduler/strategies/topologyspreadconstraint.go
@@ -110,7 +110,8 @@ func RemovePodsViolatingTopologySpreadConstraint(
 	podsForEviction := make(map[*v1.Pod]struct{})
 	// 1. for each namespace...
 	for _, namespace := range namespaces.Items {
-		if (!includedNamespaces.Has(namespace.Name) || excludedNamespaces.Has(namespace.Name)) && (includedNamespaces.Len()+excludedNamespaces.Len() > 0) {
+		if (len(includedNamespaces) > 0 && !includedNamespaces.Has(namespace.Name)) ||
+			(len(excludedNamespaces) > 0 && excludedNamespaces.Has(namespace.Name)) {
 			continue
 		}
 		namespacePods, err := client.CoreV1().Pods(namespace.Name).List(ctx, metav1.ListOptions{})

--- a/pkg/descheduler/strategies/topologyspreadconstraint_test.go
+++ b/pkg/descheduler/strategies/topologyspreadconstraint_test.go
@@ -61,6 +61,41 @@ func TestTopologySpreadConstraint(t *testing.T) {
 			namespaces:           []string{"ns1"},
 		},
 		{
+			name: "2 domains, sizes [3,1], maxSkew=1, move 1 pod to achieve [2,2], exclude kube-system namespace",
+			nodes: []*v1.Node{
+				test.BuildTestNode("n1", 2000, 3000, 10, func(n *v1.Node) { n.Labels["zone"] = "zoneA" }),
+				test.BuildTestNode("n2", 2000, 3000, 10, func(n *v1.Node) { n.Labels["zone"] = "zoneB" }),
+			},
+			pods: createTestPods([]testPodList{
+				{
+					count:  1,
+					node:   "n1",
+					labels: map[string]string{"foo": "bar"},
+					constraints: []v1.TopologySpreadConstraint{
+						{
+							MaxSkew:           1,
+							TopologyKey:       "zone",
+							WhenUnsatisfiable: v1.DoNotSchedule,
+							LabelSelector:     &metav1.LabelSelector{MatchLabels: map[string]string{"foo": "bar"}},
+						},
+					},
+				},
+				{
+					count:  2,
+					node:   "n1",
+					labels: map[string]string{"foo": "bar"},
+				},
+				{
+					count:  1,
+					node:   "n2",
+					labels: map[string]string{"foo": "bar"},
+				},
+			}),
+			expectedEvictedCount: 1,
+			strategy:             api.DeschedulerStrategy{Enabled: true, Params: &api.StrategyParameters{Namespaces: &api.Namespaces{Exclude: []string{"kube-system"}}}},
+			namespaces:           []string{"ns1"},
+		},
+		{
 			name: "2 domains, sizes [5,2], maxSkew=1, move 1 pod to achieve [4,3]",
 			nodes: []*v1.Node{
 				test.BuildTestNode("n1", 2000, 3000, 10, func(n *v1.Node) { n.Labels["zone"] = "zoneA" }),


### PR DESCRIPTION
this syncs with the upstream, specifically to pull in https://github.com/kubernetes-sigs/descheduler/pull/454 which fixes broken namespace exclusion logic in TopologySpreadConstraint and resolves the linked bugzilla