### PR TITLE
bug 1949972: Dockerfile: populate build info from pipeline envs

### DIFF
--- a/images/descheduler/Dockerfile.rhel7
+++ b/images/descheduler/Dockerfile.rhel7
@@ -1,7 +1,8 @@
 FROM registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.16-openshift-4.8 AS builder
 WORKDIR /go/src/sigs.k8s.io/descheduler
 COPY . .
-RUN go build -o descheduler ./cmd/descheduler
+ARG prefix=sigs.k8s.io/descheduler/pkg/version
+RUN go build -ldflags "-X ${prefix}.version=${OS_GIT_VERSION} -X ${prefix}.buildDate=${BUILD_RELEASE} -X ${prefix}.gitsha1=${SOURCE_GIT_COMMIT}" -o descheduler ./cmd/descheduler
 
 FROM registry.ci.openshift.org/ocp/builder:rhel-8-base-openshift-4.8
 COPY --from=builder /go/src/sigs.k8s.io/descheduler/descheduler /usr/bin/


### PR DESCRIPTION
From orchestrator.log:
```
...
FROM openshift/golang-builder:rhel_8_golang_1.16 AS builder
ENV __doozer=update BUILD_RELEASE=202104142158.p0 BUILD_VERSION=v4.8.0 OS_GIT_MAJOR=4 OS_GIT_MINOR=8 OS_GIT_PATCH=0 OS_GIT_TREE_STATE=clean OS_GIT_VERSION=4.8.0-202104142158.p0 SOURCE_GIT_TREE_STATE=clean
ENV __doozer=merge OS_GIT_COMMIT=92c2cfc OS_GIT_VERSION=4.8.0-202104142158.p0-92c2cfc SOURCE_DATE_EPOCH=1616524043 SOURCE_GIT_COMMIT=92c2cfcee48fe17854d245b8aca1ab4a2f2f7ecb SOURCE_GIT_TAG=atomic-openshift-descheduler-4.0.0-0.100.0-660-g92c2cfcee SOURCE_GIT_URL=https://github.com/openshift/descheduler
WORKDIR /go/src/sigs.k8s.io/descheduler
COPY . .
RUN go build -o descheduler ./cmd/descheduler
```

The Dockerfile is not used anywhere else but in the pipeline.

How to test it? The pipeline injects all the ENVs into the Dockerfile before the image is built. So I just injected the same envs and ran docker build.