### PR TITLE
add restricted security policy to e2e test pods

### DIFF
--- a/test/e2e/e2e_duplicatepods_test.go
+++ b/test/e2e/e2e_duplicatepods_test.go
@@ -39,6 +39,8 @@ import (
 )
 
 func TestRemoveDuplicates(t *testing.T) {
+	runAsUser := true
+	ape := false
 	ctx := context.Background()
 
 	clientSet, sharedInformerFactory, _, getPodsAssignedToNode, stopCh := initializeClient(t)
@@ -75,11 +77,25 @@ func TestRemoveDuplicates(t *testing.T) {
 					Labels: map[string]string{"app": "test-duplicate", "name": "test-duplicatePods"},
 				},
 				Spec: v1.PodSpec{
+					SecurityContext: &v1.PodSecurityContext{
+                                          RunAsNonRoot: &runAsUser,
+                                          SeccompProfile: &v1.SeccompProfile{
+                                            Type: v1.SeccompProfileTypeRuntimeDefault,
+                                          },
+                                        },
 					Containers: []v1.Container{{
 						Name:            "pause",
 						ImagePullPolicy: "Always",
 						Image:           "kubernetes/pause",
 						Ports:           []v1.ContainerPort{{ContainerPort: 80}},
+						SecurityContext: &v1.SecurityContext{
+                                                 AllowPrivilegeEscalation: &ape,
+                                                 Capabilities: &v1.Capabilities{
+                                                   Drop: []v1.Capability{
+                                                       "ALL",
+                                                   },
+                                                 },
+                                               },
 					}},
 				},
 			},

--- a/test/e2e/e2e_leaderelection_test.go
+++ b/test/e2e/e2e_leaderelection_test.go
@@ -147,6 +147,8 @@ func TestLeaderElection(t *testing.T) {
 }
 
 func createDeployment(ctx context.Context, clientSet clientset.Interface, namespace string, replicas int32, t *testing.T) (*appsv1.Deployment, error) {
+	runAsUser := true
+	ape := false
 	deployment := &appsv1.Deployment{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "leaderelection",
@@ -163,11 +165,25 @@ func createDeployment(ctx context.Context, clientSet clientset.Interface, namesp
 					Labels: map[string]string{"test": "leaderelection", "name": "test-leaderelection"},
 				},
 				Spec: v1.PodSpec{
+                                        SecurityContext: &v1.PodSecurityContext{
+                                          RunAsNonRoot: &runAsUser,
+                                          SeccompProfile: &v1.SeccompProfile{
+                                            Type: v1.SeccompProfileTypeRuntimeDefault,
+                                          },
+                                        },
 					Containers: []v1.Container{{
 						Name:            "pause",
 						ImagePullPolicy: "Always",
 						Image:           "kubernetes/pause",
 						Ports:           []v1.ContainerPort{{ContainerPort: 80}},
+						SecurityContext: &v1.SecurityContext{
+                                                  AllowPrivilegeEscalation: &ape,
+                                                  Capabilities: &v1.Capabilities{
+                                                    Drop: []v1.Capability{
+                                                        "ALL",
+                                                    },
+                                                  },
+                                                },
 					}},
 				},
 			},


### PR DESCRIPTION
While running e2e tests on OpenShift-4.12 test machine, the test logs are filled with warning messages regarding pod privileged SCC.  Also some of the tests are failing because pods can't be started with privileged SCC.

Signed-off-by: Muhammad Adeel <muhammad.adeel@ibm.com>