### PR TITLE
OCPBUGS-2726: addresses incorrect mapping from one boolean to the IncludeSoftConstraints

### DIFF
--- a/pkg/descheduler/strategy_migration.go
+++ b/pkg/descheduler/strategy_migration.go
@@ -212,7 +212,7 @@ var pluginsMap = map[string]func(ctx context.Context, nodes []*v1.Node, params *
 		args := &componentconfig.RemovePodsViolatingTopologySpreadConstraintArgs{
 			Namespaces:             params.Namespaces,
 			LabelSelector:          params.LabelSelector,
-			IncludeSoftConstraints: params.IncludePreferNoSchedule,
+			IncludeSoftConstraints: params.IncludeSoftConstraints,
 		}
 		if err := validation.ValidateRemovePodsViolatingTopologySpreadConstraintArgs(args); err != nil {
 			klog.V(1).ErrorS(err, "unable to validate plugin arguments", "pluginName", removepodsviolatingtopologyspreadconstraint.PluginName)


### PR DESCRIPTION
OCPBUGS-2726: addresses incorrect mapping from one boolean to the IncludeSoftConstraints

I can provide more debug steps, I think this is pretty clear - and it worked after changing this flag.

Signed-off-by: Paul Bastide <pbastide@redhat.com>