### PR TITLE
OCPBUGS-26169: tools/import-verifier: Sanitize path using filepath Clean

### DIFF
--- a/tools/import-verifier/import-verifier.go
+++ b/tools/import-verifier/import-verifier.go
@@ -9,6 +9,7 @@ import (
 	"log"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"strings"
 )
 
@@ -176,7 +177,7 @@ func main() {
 		log.Fatalf("%s requires the configuration file as it's only argument", os.Args[0])
 	}
 
-	configFile := os.Args[1]
+	configFile := filepath.Clean(os.Args[1])
 	importRestrictions, err := loadImportRestrictions(configFile)
 	if err != nil {
 		log.Fatalf("Failed to load import restrictions: %v", err)


### PR DESCRIPTION
```
 ✗ [Medium] Path Traversal
   ID: 8f75ad4e-f2b2-4274-8690-84ce3a77869e 
   Path: tools/import-verifier/import-verifier.go, line 306 
   Info: Unsanitized input from a CLI argument flows into io.ioutil.ReadFile, where it is used as a path. This may result in a Path Traversal vulnerability and allow an attacker to read arbitrary files.
```