### PR TITLE
UPSTREAM: <carry>: create public function to run prometheus query

### DIFF
--- a/pkg/descheduler/client/client.go
+++ b/pkg/descheduler/client/client.go
@@ -133,7 +133,9 @@ func CreatePrometheusClient(prometheusURL, authToken string, insecureSkipVerify 
 				KeepAlive: 30 * time.Second,
 			}).DialContext,
 			TLSHandshakeTimeout: 10 * time.Second,
-			TLSClientConfig:     &tls.Config{InsecureSkipVerify: true},
+			TLSClientConfig: &tls.Config{
+				InsecureSkipVerify: insecureSkipVerify,
+			},
 		}
 	} else {
 		// Retrieve Pod CA cert


### PR DESCRIPTION
Creates a public function to collect node utilization metrics through prometheus. This function is meant to be used by third party entities requiring to understand how utilized are the cluster nodes.