### PR TITLE
UPSTREAM: 1640: ReferencedResourceList: alias for map[v1.ResourceName]*resource.Quantity to avoid the type definition duplication

### DIFF
--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -18,6 +18,7 @@ package api
 
 import (
 	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 )
@@ -129,3 +130,6 @@ type SecretReference struct {
 	// name is the name of the secret.
 	Name string
 }
+
+// ReferencedResourceList is an adaption of v1.ResourceList with resources as references
+type ReferencedResourceList = map[v1.ResourceName]*resource.Quantity

--- a/pkg/descheduler/metricscollector/metricscollector_test.go
+++ b/pkg/descheduler/metricscollector/metricscollector_test.go
@@ -29,10 +29,11 @@ import (
 	fakeclientset "k8s.io/client-go/kubernetes/fake"
 	fakemetricsclient "k8s.io/metrics/pkg/client/clientset/versioned/fake"
 
+	"sigs.k8s.io/descheduler/pkg/api"
 	"sigs.k8s.io/descheduler/test"
 )
 
-func checkCpuNodeUsage(t *testing.T, usage map[v1.ResourceName]*resource.Quantity, millicpu int64) {
+func checkCpuNodeUsage(t *testing.T, usage api.ReferencedResourceList, millicpu int64) {
 	t.Logf("current node cpu usage: %v\n", usage[v1.ResourceCPU].MilliValue())
 	if usage[v1.ResourceCPU].MilliValue() != millicpu {
 		t.Fatalf("cpu node usage expected to be %v, got %v instead", millicpu, usage[v1.ResourceCPU].MilliValue())

--- a/pkg/framework/plugins/nodeutilization/highnodeutilization.go
+++ b/pkg/framework/plugins/nodeutilization/highnodeutilization.go
@@ -21,7 +21,6 @@ import (
 	"fmt"
 
 	v1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/klog/v2"
 	"sigs.k8s.io/descheduler/pkg/api"
@@ -138,7 +137,7 @@ func (h *HighNodeUtilization) Balance(ctx context.Context, nodes []*v1.Node) *fr
 	}
 
 	// stop if the total available usage has dropped to zero - no more pods can be scheduled
-	continueEvictionCond := func(nodeInfo NodeInfo, totalAvailableUsage map[v1.ResourceName]*resource.Quantity) bool {
+	continueEvictionCond := func(nodeInfo NodeInfo, totalAvailableUsage api.ReferencedResourceList) bool {
 		for name := range totalAvailableUsage {
 			if totalAvailableUsage[name].CmpInt64(0) < 1 {
 				return false

--- a/pkg/framework/plugins/nodeutilization/lownodeutilization.go
+++ b/pkg/framework/plugins/nodeutilization/lownodeutilization.go
@@ -21,7 +21,6 @@ import (
 	"fmt"
 
 	v1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/klog/v2"
 
@@ -184,7 +183,7 @@ func (l *LowNodeUtilization) Balance(ctx context.Context, nodes []*v1.Node) *fra
 	}
 
 	// stop if node utilization drops below target threshold or any of required capacity (cpu, memory, pods) is moved
-	continueEvictionCond := func(nodeInfo NodeInfo, totalAvailableUsage map[v1.ResourceName]*resource.Quantity) bool {
+	continueEvictionCond := func(nodeInfo NodeInfo, totalAvailableUsage api.ReferencedResourceList) bool {
 		if !isNodeAboveTargetUtilization(nodeInfo.NodeUsage, nodeInfo.thresholds.highResourceThreshold) {
 			return false
 		}

--- a/pkg/framework/plugins/nodeutilization/nodeutilization_test.go
+++ b/pkg/framework/plugins/nodeutilization/nodeutilization_test.go
@@ -23,6 +23,7 @@ import (
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/descheduler/pkg/api"
 )
 
 func BuildTestNodeInfo(name string, apply func(*NodeInfo)) *NodeInfo {
@@ -71,7 +72,7 @@ func TestResourceUsagePercentages(t *testing.T) {
 				},
 			},
 		},
-		usage: map[v1.ResourceName]*resource.Quantity{
+		usage: api.ReferencedResourceList{
 			v1.ResourceCPU:    resource.NewMilliQuantity(1220, resource.DecimalSI),
 			v1.ResourceMemory: resource.NewQuantity(3038982964, resource.BinarySI),
 			v1.ResourcePods:   resource.NewQuantity(11, resource.BinarySI),
@@ -103,21 +104,21 @@ func TestSortNodesByUsage(t *testing.T) {
 			name: "cpu memory pods",
 			nodeInfoList: []NodeInfo{
 				*BuildTestNodeInfo("node1", func(nodeInfo *NodeInfo) {
-					nodeInfo.usage = map[v1.ResourceName]*resource.Quantity{
+					nodeInfo.usage = api.ReferencedResourceList{
 						v1.ResourceCPU:    resource.NewMilliQuantity(1730, resource.DecimalSI),
 						v1.ResourceMemory: resource.NewQuantity(3038982964, resource.BinarySI),
 						v1.ResourcePods:   resource.NewQuantity(25, resource.BinarySI),
 					}
 				}),
 				*BuildTestNodeInfo("node2", func(nodeInfo *NodeInfo) {
-					nodeInfo.usage = map[v1.ResourceName]*resource.Quantity{
+					nodeInfo.usage = api.ReferencedResourceList{
 						v1.ResourceCPU:    resource.NewMilliQuantity(1220, resource.DecimalSI),
 						v1.ResourceMemory: resource.NewQuantity(3038982964, resource.BinarySI),
 						v1.ResourcePods:   resource.NewQuantity(11, resource.BinarySI),
 					}
 				}),
 				*BuildTestNodeInfo("node3", func(nodeInfo *NodeInfo) {
-					nodeInfo.usage = map[v1.ResourceName]*resource.Quantity{
+					nodeInfo.usage = api.ReferencedResourceList{
 						v1.ResourceCPU:    resource.NewMilliQuantity(1530, resource.DecimalSI),
 						v1.ResourceMemory: resource.NewQuantity(5038982964, resource.BinarySI),
 						v1.ResourcePods:   resource.NewQuantity(20, resource.BinarySI),
@@ -130,17 +131,17 @@ func TestSortNodesByUsage(t *testing.T) {
 			name: "memory",
 			nodeInfoList: []NodeInfo{
 				*BuildTestNodeInfo("node1", func(nodeInfo *NodeInfo) {
-					nodeInfo.usage = map[v1.ResourceName]*resource.Quantity{
+					nodeInfo.usage = api.ReferencedResourceList{
 						v1.ResourceMemory: resource.NewQuantity(3038982964, resource.BinarySI),
 					}
 				}),
 				*BuildTestNodeInfo("node2", func(nodeInfo *NodeInfo) {
-					nodeInfo.usage = map[v1.ResourceName]*resource.Quantity{
+					nodeInfo.usage = api.ReferencedResourceList{
 						v1.ResourceMemory: resource.NewQuantity(2038982964, resource.BinarySI),
 					}
 				}),
 				*BuildTestNodeInfo("node3", func(nodeInfo *NodeInfo) {
-					nodeInfo.usage = map[v1.ResourceName]*resource.Quantity{
+					nodeInfo.usage = api.ReferencedResourceList{
 						v1.ResourceMemory: resource.NewQuantity(5038982964, resource.BinarySI),
 					}
 				}),


### PR DESCRIPTION

Cherry picks the upstream PR while also makes the prometheus usage client to use the new type (prometheus usage client isn't present in upstream just yet)