### PR TITLE
no-jira: .tekton: new task updates require IMAGE_URL and IMAGE_DIGEST envs to be present for apply-tags task

### DIFF
--- a/.tekton/descheduler-4-19-pull-request.yaml
+++ b/.tekton/descheduler-4-19-pull-request.yaml
@@ -547,6 +547,10 @@ spec:
       params:
       - name: IMAGE
         value: $(tasks.build-image-index.results.IMAGE_URL)
+      - name: IMAGE_URL
+        value: $(tasks.build-image-index.results.IMAGE_URL)
+      - name: IMAGE_DIGEST
+        value: $(tasks.build-image-index.results.IMAGE_DIGEST)
       runAfter:
       - build-image-index
       taskRef:

--- a/.tekton/descheduler-4-19-push.yaml
+++ b/.tekton/descheduler-4-19-push.yaml
@@ -544,6 +544,10 @@ spec:
       params:
       - name: IMAGE
         value: $(tasks.build-image-index.results.IMAGE_URL)
+      - name: IMAGE_URL
+        value: $(tasks.build-image-index.results.IMAGE_URL)
+      - name: IMAGE_DIGEST
+        value: $(tasks.build-image-index.results.IMAGE_DIGEST)
       runAfter:
       - build-image-index
       taskRef:


### PR DESCRIPTION
SSIA