### PR TITLE
UPSTREAM: <carry>: [tekton]: undo build pipeline SA migration

### DIFF
--- a/.tekton/descheduler-4-20-pull-request.yaml
+++ b/.tekton/descheduler-4-20-pull-request.yaml
@@ -606,8 +606,7 @@ spec:
       optional: true
     - name: netrc
       optional: true
-  taskRunTemplate:
-    serviceAccountName: build-pipeline-descheduler-4-20
+  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:

--- a/.tekton/descheduler-4-20-push.yaml
+++ b/.tekton/descheduler-4-20-push.yaml
@@ -603,8 +603,7 @@ spec:
       optional: true
     - name: netrc
       optional: true
-  taskRunTemplate:
-    serviceAccountName: build-pipeline-descheduler-4-20
+  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:


### PR DESCRIPTION
```
failed to create task run pod "kube-descheduler-operator-4-20-on-push-qmx6t-init": translating TaskSpec to Pod: serviceaccounts "build-pipeline-kube-descheduler-operator-4-20" not found. Maybe missing or invalid Task kdo-workloads-tenant/
```